### PR TITLE
Fix warnings reported at compilation time

### DIFF
--- a/src/aiori-MPIIO.c
+++ b/src/aiori-MPIIO.c
@@ -271,10 +271,14 @@ static IOR_offset_t MPIIO_Xfer(int access, void *fd, IOR_size_t * buffer,
 
         /* point functions to appropriate MPIIO calls */
         if (access == WRITE) {  /* WRITE */
-                Access = MPI_File_write;
-                Access_at = MPI_File_write_at;
-                Access_all = MPI_File_write_all;
-                Access_at_all = MPI_File_write_at_all;
+                Access = (int (MPIAPI *)(MPI_File, void *, int,
+                          MPI_Datatype, MPI_Status *)) MPI_File_write;
+                Access_at = (int (MPIAPI *)(MPI_File, MPI_Offset, void *, int,
+                             MPI_Datatype, MPI_Status *))  MPI_File_write_at;
+                Access_all = (int (MPIAPI *) (MPI_File, void *, int,
+                              MPI_Datatype, MPI_Status *)) MPI_File_write_all;
+                Access_at_all = (int (MPIAPI *) (MPI_File, MPI_Offset, void *, int,
+                                 MPI_Datatype, MPI_Status *)) MPI_File_write_at_all;
                 /*
                  * this needs to be properly implemented:
                  *
@@ -414,9 +418,6 @@ void MPIIO_Delete(char *testFileName, IOR_param_t * param)
 static char* MPIIO_GetVersion()
 {
   static char ver[1024] = {};
-  if (ver){
-    return ver;
-  }
   int version, subversion;
   MPI_CHECK(MPI_Get_version(&version, &subversion), "cannot get MPI version");
   sprintf(ver, "(%d.%d)", version, subversion);

--- a/src/ior-output.c
+++ b/src/ior-output.c
@@ -52,12 +52,6 @@ static void PrintKeyValStart(char * key){
   }
 }
 
-static void PrintNewLine(){
-  if (outputFormat == OUTPUT_DEFAULT){
-    fprintf(out_resultfile, "\n");
-  }
-}
-
 static void PrintNextToken(){
   if(needNextToken){
     needNextToken = 0;

--- a/src/ior.c
+++ b/src/ior.c
@@ -92,7 +92,6 @@ IOR_test_t * ior_run(int argc, char **argv, MPI_Comm world_com, FILE * world_out
 
 int ior_main(int argc, char **argv)
 {
-    int i;
     IOR_test_t *tests_head;
     IOR_test_t *tptr;
 
@@ -616,7 +615,6 @@ FillIncompressibleBuffer(void* buffer, IOR_param_t * test)
                 lo = (unsigned long long) rand_r(&test->incompressibleSeed);
                 buf[i] = hi | lo;
         }
-
 }
 
 unsigned int reseed_incompressible_prng = TRUE;
@@ -935,7 +933,6 @@ static void RemoveFile(char *testFileName, int filePerProc, IOR_param_t * test)
  */
 static void InitTests(IOR_test_t *tests, MPI_Comm com)
 {
-        IOR_test_t *testsHead = tests;
         int size;
 
         MPI_CHECK(MPI_Comm_size(com, & size), "MPI_Comm_size() error");
@@ -1837,7 +1834,6 @@ static IOR_offset_t WriteOrReadSingle(IOR_offset_t pairCnt, IOR_offset_t *offset
 static IOR_offset_t WriteOrRead(IOR_param_t * test, IOR_results_t * results, void *fd, int access, IOR_io_buffers* ioBuffers)
 {
         int errors = 0;
-        IOR_offset_t amtXferred;
         IOR_offset_t transferCount = 0;
         uint64_t pairCnt = 0;
         IOR_offset_t *offsetArray;

--- a/src/ior.h
+++ b/src/ior.h
@@ -140,7 +140,7 @@ typedef struct
     unsigned int timeStampSignatureValue; /* value for time stamp signature */
     void * fd_fppReadCheck;          /* additional fd for fpp read check */
     int randomSeed;                  /* random seed for write/read check */
-    int incompressibleSeed;           /* random seed for incompressible file creation */
+    unsigned int incompressibleSeed; /* random seed for incompressible file creation */
     int randomOffset;                /* access is to random offsets */
     size_t memoryPerTask;            /* additional memory used per task */
     size_t memoryPerNode;            /* additional memory used per node */

--- a/src/mdtest.c
+++ b/src/mdtest.c
@@ -86,7 +86,6 @@ static char testdirpath[MAX_PATHLEN];
 static char base_tree_name[MAX_PATHLEN];
 static char **filenames;
 static char hostname[MAX_PATHLEN];
-static char unique_dir[MAX_PATHLEN];
 static char mk_name[MAX_PATHLEN];
 static char stat_name[MAX_PATHLEN];
 static char read_name[MAX_PATHLEN];
@@ -384,8 +383,6 @@ static void create_file (const char *path, uint64_t itemNum) {
 /* helper for creating/removing items */
 void create_remove_items_helper(const int dirs, const int create, const char *path,
                                 uint64_t itemNum, rank_progress_t * progress) {
-
-    char curr_item[MAX_PATHLEN];
 
     if (( rank == 0 ) && ( verbose >= 1 )) {
         fprintf( out_logfile, "V-1: Entering create_remove_items_helper...\n" );
@@ -1564,9 +1561,9 @@ void summarize_results(int iterations) {
 /* Checks to see if the test setup is valid.  If it isn't, fail. */
 void valid_tests() {
 
-    if(stone_wall_timer_seconds > 0 && branch_factor > 1 || ! barriers){
-      fprintf(out_logfile, "Error, stone wall timer does only work with a branch factor <= 1 and with barriers\n");
-      MPI_Abort(testComm, 1);
+    if (((stone_wall_timer_seconds > 0) && (branch_factor > 1)) || ! barriers) {
+        fprintf(out_logfile, "Error, stone wall timer does only work with a branch factor <= 1 and with barriers\n");
+        MPI_Abort(testComm, 1);
     }
 
     if (!create_only && !stat_only && !read_only && !remove_only) {
@@ -1859,7 +1856,7 @@ static void mdtest_iteration(int i, int j, MPI_Group testgroup, mdtest_results_t
 
   /* start and end times of directory tree create/remove */
   double startCreate, endCreate;
-  int k, c;
+  int k;
 
   if (rank == 0 && verbose >= 1) {
       fprintf(out_logfile, "V-1: main: * iteration %d *\n", j+1);
@@ -2149,7 +2146,7 @@ mdtest_results_t * mdtest_run(int argc, char **argv, MPI_Comm world_com, FILE * 
     init_clock();
 
     mdtest_init_args();
-    int i, j, k;
+    int i, j;
     int nodeCount;
     MPI_Group worldgroup, testgroup;
     struct {
@@ -2393,7 +2390,10 @@ mdtest_results_t * mdtest_run(int argc, char **argv, MPI_Comm world_com, FILE * 
 
     /* setup directory path to work in */
     if (path_count == 0) { /* special case where no directory path provided with '-d' option */
-        char * dir = getcwd(testdirpath, MAX_PATHLEN);
+        char *ret = getcwd(testdirpath, MAX_PATHLEN);
+        if (ret == NULL) {
+            FAIL("Unable to get current working directory");
+        }
         path_count = 1;
     } else {
         strcpy(testdirpath, filenames[rank%path_count]);

--- a/src/parse_options.c
+++ b/src/parse_options.c
@@ -499,7 +499,6 @@ IOR_test_t *ParseCommandLine(int argc, char **argv)
           LAST_OPTION,
         };
 
-        int i;
         IOR_test_t *tests = NULL;
 
         GetPlatformName(initialTestParams.platform);

--- a/src/test/lib.c
+++ b/src/test/lib.c
@@ -3,18 +3,30 @@
 
 int main(int argc, char ** argv){
   int rank;
+  int ret = 0;
+
   MPI_Init(& argc, & argv);
   MPI_Comm_rank(MPI_COMM_WORLD, & rank);
 
   if (rank == 0){
     char * param[] = {"./ior", "-a", "DUMMY"};
     IOR_test_t * res = ior_run(3, param, MPI_COMM_SELF, stdout);
+    if (res == NULL)
+    {
+        fprintf(stderr, "Could not run ior\n");
+        ret = 1;
+    }
   }
   if (rank == 0){
     char * param[] = {"./mdtest", "-a", "DUMMY"};
     mdtest_results_t * res = mdtest_run(3, param, MPI_COMM_SELF, stdout);
+    if (res == NULL)
+    {
+        fprintf(stderr, "Could not run mdtest\n");
+        ret = 1;
+    }
   }
   MPI_Finalize();
 
-  return 0;
+  return ret;
 }

--- a/src/utilities.c
+++ b/src/utilities.c
@@ -136,7 +136,7 @@ void DumpBuffer(void *buffer,
 int CountTasksPerNode(MPI_Comm comm) {
     /* modern MPI provides a simple way to get the local process count */
     MPI_Comm shared_comm;
-    int rc, count;
+    int count;
 
     MPI_Comm_split_type (comm, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &shared_comm);
     MPI_Comm_size (shared_comm, &count);


### PR DESCRIPTION
This patch fixes most of the warnings caused
by unused variables and assignments from incompatible
type.